### PR TITLE
Cruft entries from changes during review

### DIFF
--- a/labels.yaml
+++ b/labels.yaml
@@ -378,18 +378,6 @@ default:
         - name: wontfix
       target: both
       addedBy: humans
-    - color: fc05d7
-      description: Indicates an issue/PR is related to end-user documentation.
-      name: users/documentation
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - color: fc05d7
-      description: Indicates an issue/PR is user experience (UX).
-      name: user/experience
-      target: both
-      prowPlugin: label
-      addedBy: anyone
 
 repos:
   operate-first/SRE:


### PR DESCRIPTION
- In https://github.com/thoth-station/thoth-application/pull/1611 we ended up with a specific set of changes for how the labels would appear
- In doing the final editing for that, I accidentally left these two labels that do not conform to the Prow scheme, nor are they what we intended to have happen from review.
- These labels shouldn't have been used anywhere already

Signed-off by: Karsten Wade <kwade@redhat.com>