### PR TITLE
feat: Add community-handbook repo

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -82,6 +82,10 @@ orgs:
       community:
         default_branch: main
         has_projects: false
+      community-handbook:
+        default_branch: main
+        description: Community Handbook for Operate First contributors
+        has_projects: false
       continuous-delivery:
         description: Continuous Delivery
         has_projects: false
@@ -171,6 +175,7 @@ orgs:
           blueprint: admin
           common: admin
           community: admin
+          community-handbook: admin
           continuous-delivery: admin
           continuous-deployment: admin
           curator: admin
@@ -204,6 +209,7 @@ orgs:
           blueprint: admin
           common: admin
           community: admin
+          community-handbook: admin
           continuous-delivery: admin
           continuous-deployment: admin
           curator: admin
@@ -219,6 +225,18 @@ orgs:
           template: admin
           toolbox: admin
           workshop-apps: admin
+      community-admins:
+        descriptions: Admins for community oriented repos
+        maintainers:
+          - quaid
+        members:
+          - margarethaley
+          - billburnseh
+          - durandom
+        privacy: closed
+        repos:
+          community: admin
+          community-handbook: admin
       contributors-core:
         description:
           The operate-first contributor team consists of all org members that
@@ -257,6 +275,7 @@ orgs:
           blueprint: triage
           common: triage
           community: triage
+          community-handbook: triage
           continuous-delivery: triage
           continuous-deployment: triage
           curator: triage
@@ -306,6 +325,7 @@ orgs:
           argocd-apps: write
           blueprint: write
           community: write
+          community-handbook: write
           continuous-delivery: write
           continuous-deployment: write
           curator: write


### PR DESCRIPTION
Resolves: https://github.com/operate-first/common/issues/6


please review and leave on hold for a coordinated merge, I want to create the repo from a template - which has to be done manually right now.
/hold