### PR TITLE
feat: Add sre-apprenticeship

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -133,6 +133,9 @@ orgs:
       opfcli:
         default_branch: main
         has_projects: false
+      sre-apprenticeship:
+        default_branch: main
+        description: Issue tracker for the SRE Apprenticeship
       support:
         default_branch: main
         description:
@@ -193,6 +196,7 @@ orgs:
           operate-first-twitter: admin
           operate-first.github.io: admin
           opfcli: admin
+          sre-apprenticeship: admin
           support: admin
           template: admin
           toolbox: admin
@@ -228,6 +232,7 @@ orgs:
           operate-first-twitter: admin
           operate-first.github.io: admin
           opfcli: admin
+          sre-apprenticeship: admin
           support: admin
           template: admin
           toolbox: admin
@@ -296,6 +301,7 @@ orgs:
           operate-first-twitter: triage
           operate-first.github.io: triage
           opfcli: triage
+          sre-apprenticeship: triage
           support: triage
           template: triage
           toolbox: triage
@@ -347,6 +353,7 @@ orgs:
           operate-first-twitter: write
           operate-first.github.io: write
           opfcli: write
+          sre-apprenticeship: write
           support: write
           template: write
           toolbox: write


### PR DESCRIPTION
cc @durandom 

I've noticed the repo you've created is missing from the config hence syncing. Do you want to add any additional RBAC in here?

https://github.com/operate-first/sre-apprenticeship