### PR TITLE
feat: Remove Aaaaazzaa user which no longer exists

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -16,7 +16,6 @@ orgs:
     location: ""
     members:
       - 4n4nd
-      - Aaaaazzaa
       - aakankshaduggal
       - accorvin
       - anishasthana
@@ -256,7 +255,6 @@ orgs:
           - HumairAK
         members:
           - 4n4nd
-          - Aaaaazzaa
           - Gregory-Pereira
           - MichaelClifford
           - Shreyanand


### PR DESCRIPTION
Breaks the automation runs, since the user no longer exists in GitHub

https://github.com/Aaaaazzaa


Fixes:
````
{"component":"peribolos","file":"prow/cmd/peribolos/main.go:215","func":"main.main","level":"fatal","msg":"Configuration failed: failed to configure operate-first teams: failed to update contributors-core members: UpdateTeamMembership(4506398(contributors-core), aaaaazzaa, false) failed: status code 404 not one of [200], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/reference/teams#add-or-update-team-membership-for-a-user\"}","severity":"fatal","time":"2021-09-20T16:20:49+02:00"}
```