### PR TITLE
Remove duplicate user in contributors-core.

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -286,7 +286,6 @@ orgs:
           - mimotej
           - oindrillac
           - PARTHSONI95
-          - slntpts
           - quaid
           - rbo
           - schwesig


### PR DESCRIPTION
Introduced twice in https://github.com/operate-first/common/pull/26 accidentally. 