### PR TITLE
Add operate-first user.

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -44,6 +44,7 @@ orgs:
       - mimotej
       - naved001
       - oindrillac
+      - op1st
       - pacospace
       - PARTHSONI95
       - quaid
@@ -178,6 +179,7 @@ orgs:
         description: This is our SourceOps team, they keep the source fresh.
         maintainers:
           - sesheta
+          - op1st
         privacy: closed
         repos:
           SRE: admin


### PR DESCRIPTION
Related: https://github.com/thoth-station/support/issues/68

I think we should have one distinct from thoth that's specific to the operate-first org.