### PR TITLE
Added new `training` repo

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -168,6 +168,9 @@ orgs:
       toolbox:
         description: Toolbox for Operate-First tooling
         has_projects: false
+      training:
+        description: All training content for users and contributors
+        has_projects: false
       workshop-apps:
         default_branch: main
         description: "Repository of ArgoCD application for workshop purposes "


### PR DESCRIPTION
- Closes issue #39 
- As per the discussion in issue #39, we are going to start with one repo and
  have clearly named individual jupyter notebooks per course