### PR TITLE
New SRE repo

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -169,6 +169,10 @@ orgs:
         default_branch: main
         description: Evaluate&Store Engine for OpenSLO–defined Objectives
         has_projects: false
+      sre:
+        default_branch: main
+        description: SRE content
+        has_projects: false
       sre-apprenticeship:
         default_branch: main
         description: Issue tracker for the SRE Apprenticeship
@@ -448,3 +452,4 @@ orgs:
         privacy: closed
         repos:
           slo-evaluator: admin
+          sre: admin

--- a/github-config.yaml
+++ b/github-config.yaml
@@ -90,8 +90,6 @@ orgs:
         description:
           The sig-operations repository.
         has_projects: false
-        previously:
-          - sre
       alerts:
         default_branch: main
         description: Bots posting alerts from our clusters


### PR DESCRIPTION
Readd a blank `sre` repo to be filled with general SRE–related materials.

For this repo to be created, I had to also remove the existing `sre` –> `operations` redirect, cause that caused a conflict. If need be, a "hey, you might be looking for /operations repo" note can be added near the top of README.md in the new `sre` repo.