### PR TITLE
:exclamation: Peribolos binaries is shifted to /ko-app/ dir

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -25,7 +25,7 @@ presubmits:
             - -c
             - |
               set -ex
-              /peribolos --config-path github-config.yaml --github-token-path /etc/github/oauth \
+              /ko-app/peribolos --config-path github-config.yaml --github-token-path /etc/github/oauth \
                 --min-admins=2 \
                 --maximum-removal-delta=0.15 \
                 --require-self=true \
@@ -86,7 +86,7 @@ postsubmits:
             - -c
             - |
               set -ex
-              /peribolos --config-path github-config.yaml --github-token-path /etc/github/oauth \
+              /ko-app/peribolos --config-path github-config.yaml --github-token-path /etc/github/oauth \
                 --min-admins=2 \
                 --maximum-removal-delta=0.15 \
                 --require-self=true \


### PR DESCRIPTION
Peribolos binaries is shifted to `/ko-app/` dir
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


Related-to: https://github.com/operate-first/common/pull/71#issuecomment-1051284913


Reference: https://github.com/kubernetes/test-infra/blob/198fd8ef3d2441af01a0fad802ec9809b162e599/prow/ANNOUNCEMENTS.md?plain=1#L195