### PR TITLE
Add myself @stefwalter as a member of Operate First

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -84,6 +84,7 @@ orgs:
       - sindhuvahinis
       - skanthed
       - slntpts
+      - stefwalter
       - stefwrite
       - suppathak
       - thegreymanshow


### PR DESCRIPTION
This would allow me be assigned issues, create discussions,
and have CI run on my jobs. I'm working on the Open Source Services
aspect of Operate First.

As recommended by @[HumairAK](https://github.com/HumairAK)

https://github.com/operate-first/community/pull/154#issuecomment-1072489912