### PR TITLE
add operate-first-in-action repo

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -172,6 +172,10 @@ orgs:
         has_wiki: false
       odh-dashboard:
         has_projects: false
+      operate-first-in-action:
+        default_branch: main
+        description: This repository will serve as the content hub for our 2022 summit video "Operate First In Action"
+        has_project: false
       operate-first-twitter:
         default_branch: main
         description:


### PR DESCRIPTION
This PR updates the github-config.yaml to add a repo for the "Operate First In Action" summit content. 