### PR TITLE
 Labels related to SIGs

### DIFF
--- a/labels.yaml
+++ b/labels.yaml
@@ -253,6 +253,12 @@ default:
         - name: triage/support
       target: both
       addedBy: humans
+    - color: c7def8
+      description: Indicates an issue/PR is related to Special Interest Groups (SIGs)
+      name: kind/sigs
+      target: both
+      prowPlugin: label
+      addedBy: anyone
     - color: 8b55d4
       description: Connects an issue/PR with a particular user persona.
       name: kind/undergrad-student
@@ -454,6 +460,19 @@ default:
       target: both
       prowPlugin: label
       addedBy: anyone
+    - color: fef2c0
+      description: Categorizes an issue or PR as relevant to SIG Community
+      name: sig/community
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: fef2c0
+      description: Categorizes an issue or PR as relevant to SIG Operations
+      name: sig/operations
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+
 
     - color: 8fc951
       description: Indicates an issue or PR is ready to be actively worked on.
@@ -492,59 +511,16 @@ default:
         - name: wontfix
       target: both
       addedBy: humans
-    - color: "5319e7"
-      description: Notify first-operator bot that issue should be assigned to oncall.
-      name: bot/assign-to-oncall
-      target: issue
-      addedBy: anyone
-    - color: ffce30
-      description: This issue affects the Smaug cluster.
-      name: cluster/smaug
+    - color: fc05d7
+      description: Indicates an issue/PR is related to end-user documentation.
+      name: users/documentation
+      target: both
       prowPlugin: label
       addedBy: anyone
-    - color: ffce30
-      description: This issue affects the Balrog cluster.
-      name: cluster/balrog
-      prowPlugin: label
-      addedBy: anyone
-    - color: ffce30
-      description: This issue affects the Infra cluster.
-      name: cluster/infra
-      prowPlugin: label
-      addedBy: anyone
-    - color: ffce30
-      description: This issue affects the Rick cluster.
-      name: cluster/rick
-      prowPlugin: label
-      addedBy: anyone
-    - color: ffce30
-      description: This issue affects the Morty cluster.
-      name: cluster/morty
-      prowPlugin: label
-      addedBy: anyone
-    - color: ffce30
-      description: This issue affects the osc-cl1 cluster.
-      name: cluster/osc-cl1
-      prowPlugin: label
-      addedBy: anyone
-    - color: ffce30
-      description: This issue affects the osc-cl2 cluster.
-      name: cluster/osc-cl2
-      prowPlugin: label
-      addedBy: anyone
-    - color: ffce30
-      description: This issue affects the Curator cluster.
-      name: cluster/curator
-      prowPlugin: label
-      addedBy: anyone
-    - color: ffce30
-      description: This issue affects the OCP Prod cluster.
-      name: cluster/ocp-prod
-      prowPlugin: label
-      addedBy: anyone
-    - color: ffce30
-      description: This issue affects the OCP-Stage cluster.
-      name: cluster/ocp-stage
+    - color: fc05d7
+      description: Indicates an issue/PR is user experience (UX).
+      name: user/experience
+      target: both
       prowPlugin: label
       addedBy: anyone
 


### PR DESCRIPTION
Adds labels for existing SIGs from the new charter, and a generic label so anything can be associated with SIGs overall/in-general.

Remake of #92 after rebasing.

All credit for this should go to @quaid, I am just hoping this fixes his git issue.