### PR TITLE
Creating a new `blog` repo and related teams

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -369,7 +369,8 @@ orgs:
         privacy: closed
         members:
           - quaid
-          - coglhanRH
+          - coghlanRH
+
           - stefwrite
         repos:
             blog: write

--- a/github-config.yaml
+++ b/github-config.yaml
@@ -340,13 +340,13 @@ orgs:
         description: Writers and reviewers of Op1st blog posts
         privacy: closed  # Keep as closed, more info: https://docs.github.com/en/rest/reference/teams#create-a-team
         members:
-          - jeremyeder
-          - david-martin
+          - aakankshaduggal
           - akrawczy
           - amfred
           - billburnseh
           - bryanmontalvan
           - coghlanRH
+          - david-martin
           - hemajv
           - hpdempsey
           - jeremyeder
@@ -356,6 +356,7 @@ orgs:
           - MichaelTiemannOSC
           - mmazur
           - msdisme
+          - oindrillac
           - quaid
           - R-Lawton
           - sallyom

--- a/github-config.yaml
+++ b/github-config.yaml
@@ -121,6 +121,9 @@ orgs:
       apps:
         description: Operate-first application manifests
         has_projects: false
+      blog:
+        description: Home for blog tooling, posts, and guidelines
+        has_projects: false
       blueprint:
         default_branch: main
         description: This is the blueprint for the Operate First Initiative
@@ -333,6 +336,49 @@ orgs:
         privacy: closed
         repos:
           ai-for-cloud-ops: admin
+      blog:
+        description: Writers and reviewers of Op1st blog posts
+        privacy: closed  # Keep as closed, more info: https://docs.github.com/en/rest/reference/teams#create-a-team
+        members:
+          - jeremyeder
+          - david-martin
+          - akrawczy
+          - amfred
+          - billburnseh
+          - bryanmontalvan
+          - coghlanRH
+          - hemajv
+          - hpdempsey
+          - jeremyeder
+          - larsks
+          - margarethaley
+          - MichaelClifford
+          - MichaelTiemannOSC
+          - mmazur
+          - msdisme
+          - quaid
+          - R-Lawton
+          - sallyom
+          - schwesig
+          - stefwalter
+          - stefwrite
+        repos:
+          blog: triage
+      blog-editorial:
+        description: Editors who are allowed to edit and publish blog posts
+        privacy: closed
+        members:
+          - quaid
+          - coglhanRH
+          - stefwrite
+        repos:
+            blog: write
+      blog-publishers:
+        description: Team that can rework the blog platform and make ultimate publishing decisions
+        privacy: closed
+        members:
+          - durandom
+          - quaid
       community-admins:
         descriptions: Admins for community oriented repos
         maintainers:

--- a/github-config.yaml
+++ b/github-config.yaml
@@ -371,7 +371,7 @@ orgs:
         members:
           - quaid
           - coghlanRH
-
+          - jeremyeder
           - stefwrite
         repos:
             blog: write


### PR DESCRIPTION
- This is the home to the tooling, content, and processes/guidelines
  for the blog.
- Blog tasks that happen in this repo:
  - Writing
  - Reviewing
  - Publishing (tooling)
  - Pull request blog posts
    - Review via PR process
- Three teams:
  - 'blog' is for all the people possible, to make the pool of writers
    and reviewers as big as possible.
  - 'blog-editorial' is for people who can approve PRs (so they get
    published automatically) and can make changes to blog posts before
    and after publication.
  - 'blog-publishers' is for people who need to be able to manipulate
    the repo so it can be hooked up for automatic publishing.

Two possible URLs for the blog are:
1. blog.operate-first.cloud
1. operate-first.cloud/blog

I prefer the sub-domain 'blog.operate-first.cloud', but I always like
to use subdomains.

Signed-off-by: Karsten Wade <kwade@redhat.com>