### PR TITLE
Add dastergon to the org

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -39,6 +39,7 @@ orgs:
       - codificat
       - coghlanRH
       - DanNiESh
+      - dastergon
       - david-martin
       - dystewart
       - erikerlandson


### PR DESCRIPTION
Adding @dastergon to the org in support of operate-first/sre#16, to address https://github.com/operate-first/sre/pull/16#issuecomment-1127725125