### PR TITLE
Forgot to create maintainers for the blog

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -365,6 +365,11 @@ orgs:
       blog:
         description: Writers and reviewers of Op1st blog posts
         privacy: closed  # Keep as closed, more info: https://docs.github.com/en/rest/reference/teams#create-a-team
+        maintainers:
+          - quaid
+          - jeremyeder
+          - mhild
+          - mmazur
         members:
           - aakankshaduggal
           - akrawczy
@@ -394,6 +399,11 @@ orgs:
       blog-editorial:
         description: Editors who are allowed to edit and publish blog posts
         privacy: closed
+        maintainers:
+          - quaid
+          - jeremyeder
+          - mhild
+          - mmazur
         members:
           - quaid
           - coghlanRH
@@ -404,9 +414,11 @@ orgs:
       blog-publishers:
         description: Team that can rework the blog platform and make ultimate publishing decisions
         privacy: closed
-        members:
+        maintainers:
           - durandom
           - quaid
+        repos:
+          blog: admin
       community-admins:
         descriptions: Admins for community oriented repos
         maintainers:


### PR DESCRIPTION
- This should fill out the roles properly now
- Note the cascading roles, hoping someone else can confirm I have
  the cascade correct
  `blog` members can write and review (`triage` the repo)
  `blog-editorial` members can review and publish (`write` in the
   repo)
  `blog-publishers` members can rework the publishing platform
  ... but what is the difference between `maintainers` and
      `members` and do I have it configured correctly?
      - e.g. should maintainers also be in the members list?

Signed-off-by: Karsten Wade <kwade@redhat.com>