### PR TITLE
Creating group to maintain project websites

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -639,3 +639,13 @@ orgs:
         privacy: closed
         repos:
           sre-u: admin
+      website:
+        description: A team maintaining any websites/webpages for the project
+        maintainers:
+          bryanmontalvan
+          quaid
+          schwesig
+        members:
+          stefwrite
+        repos:
+          operate-first.github.io: admin


### PR DESCRIPTION
- Currently just the one repo but could be other repos that drive
  web properties
- This lets a group triage and maintain the website, currently the
  Website Updates WG
- Adding myself as part of the group doing things in the WG and
  having value from being able to approve and merge each other's
  changes.
  - One member does not aiui currently wish to be a maintainer for
    anything new due to time constraints, so not having the auth
    to publish means she won't be called to help there.
  - My other reason for adding myself is my leadership role requires
    me to be able to push changes to the website when I deem them
    to be timely, including overriding normal gitops review and
    manually merging myself.

Signed-off-by: Karsten Wade <kwade@redhat.com>