### PR TITLE
fix: sre-u has no main branch

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -238,7 +238,7 @@ orgs:
         description: SRE content
         has_projects: false
       sre-u:
-        default_branch: main
+        default_branch: master
         description: SRE-U content
         has_projects: false
       sre-apprenticeship:


### PR DESCRIPTION
sre-u has no `main` branch

![image](https://user-images.githubusercontent.com/7453394/172567525-c3797968-b322-4985-818d-00ad6726b655.png)
