### PR TITLE
requesting approvers permissions in operate-first/common

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@
 approvers:
   - durandom
   - goern
+  - Gregory-Pereira
   - HumairAK
   - larsks
   - schwesig
@@ -9,6 +10,7 @@ approvers:
 reviewers:
   - durandom
   - goern
+  - Gregory-Pereira
   - harshad16
   - HumairAK
   - larsks


### PR DESCRIPTION
With Approvers permissions I can expedite requests to join the operate-first team, and seeing as I am an admin in operate-first, this followed logically as somewhere I could pickup slack.

Signed-off-by: greg pereira <grpereir@redhat.com>