### PR TITLE
Add ryanaslett to members,create osc-admins team

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -120,9 +120,10 @@ orgs:
       - rimolive
       - riprasad
       - roastdeer
-      - rootfs
       - RobotSail
+      - rootfs
       - roytman
+      - ryanaslett
       - rynofinn
       - saadullah01
       - sallyom
@@ -725,3 +726,17 @@ orgs:
         privacy: closed
         repos:
           kepler-edge-demo: admin
+      osc-admins:
+        description: Additional privileges to relevant repositories for OS-Climate project admins
+        maintainers:
+          - erikerlandson
+          - mightynerderic
+          - redmikhail
+        members:
+          - caldeirav
+          - ryanaslett
+        privacy: closed
+        repos:
+          apps: admin
+          odh-manifests: admin
+          support: write


### PR DESCRIPTION
To simplify merge process for members of the OS-Climate project adding separate `osc-admins` team as per discussion from SIG-Operations meeting on Dec 06, 2022