### PR TITLE
Add Apex Team Members

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -53,6 +53,7 @@ orgs:
       - cyberox
       - DanNiESh
       - dastergon
+      - dave-tucker
       - david-martin
       - dinogun
       - djach7
@@ -111,6 +112,7 @@ orgs:
       - mtoslalibu
       - mubariskhan96
       - naved001
+      - nerdalert
       - oindrillac
       - op1st
       - pacospace
@@ -133,6 +135,7 @@ orgs:
       - roytman
       - ryanaslett
       - rynofinn
+      - russellb
       - saadullah01
       - sallyom
       - SamoKopecky
@@ -160,6 +163,7 @@ orgs:
       - uffish
       - VannTen
       - veniceofcode
+      - vishnoianil
       - vpavlin
       - vrutkovs
       - zaoxing


### PR DESCRIPTION
Adds the apex team members to the operate-first org.