### PR TITLE
Add OS-Climate sostrades team users as members of the org

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -147,6 +147,8 @@ orgs:
       - sindhuvahinis
       - skanthed
       - slntpts
+      - sostrades-radouanbouadel
+      - sostrades-dpeltre
       - Spirit328
       - stefwalter
       - stefwrite


### PR DESCRIPTION
Add OS-Climate sostrades team as members of the operate-first organization to allow access to ArgoCD and ability to submit PR requests for managing relevant objects on OS-Climate clusters. This is replacement for PR https://github.com/operate-first/common/pull/161 , addressing all issues. Original PR could be closed 