### PR TITLE
Adding 'quaid' as org owner/admin

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -4,6 +4,7 @@ orgs:
       - durandom
       - goern
       - HumairAK
+      - quaid
       - schwesig
       - sesheta
       - tumido
@@ -399,6 +400,7 @@ orgs:
         maintainers:
           - tumido
           - HumairAK
+          - quaid
         members:
           - larsks
         privacy: closed


### PR DESCRIPTION
Proposing my promotion to org admin and general Operate First maintainer.

As part of the shift away from ET leadership in the project, we need a project lead who is tasked by their organization to do this work. At the moment that seems to be only me, therefore it is prudent to have me attain higher permission levels. In addition, I've been an active and impactful member of the community for almost two years, and have earned maintainer status by any rubric.